### PR TITLE
Use dtolnay/rust-toolchain instead of actions-rs/toolchain

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -14,10 +14,8 @@ jobs:
       - uses: actions/checkout@v3.5.2
 
       - name: install clippy
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
           components: clippy
 
       - name: check clippy version


### PR DESCRIPTION
`actions-rs/toolchain` はメンテ止まってて使わない方がいいので，乗り換え