### PR TITLE
Use sudo when accesing /usr/local

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
         REVIEWDOG_VERSION: "v0.15.0"
       run: |
         curl -sfL "https://raw.githubusercontent.com/${REVIEWDOG_REPO}/master/install.sh" \
-          | sh -s -- -b /usr/local/bin/ "${REVIEWDOG_VERSION}"
+          | sudo sh -s -- -b /usr/local/bin/ "${REVIEWDOG_VERSION}"
 
     - name: install clippy-reviewdog-filter
       shell: bash
@@ -71,8 +71,8 @@ runs:
         CLIPPY_REVIEWDOG_FILTER_VERSION: "v0.1.1"
       run: |
         curl -sLJO "https://github.com/${CLIPPY_REVIEWDOG_FILTER_REPO}/releases/download/${CLIPPY_REVIEWDOG_FILTER_VERSION}/clippy-reviewdog-filter-x86_64-unknown-linux-musl"
-        mv clippy-reviewdog-filter-x86_64-unknown-linux-musl /usr/local/bin/clippy-reviewdog-filter
-        chmod +x /usr/local/bin/clippy-reviewdog-filter
+        chmod +x clippy-reviewdog-filter-x86_64-unknown-linux-musl
+        sudo mv clippy-reviewdog-filter-x86_64-unknown-linux-musl /usr/local/bin/clippy-reviewdog-filter
         clippy-reviewdog-filter --version
 
     - name: clippy & reviewdog


### PR DESCRIPTION
Something has changed with github runners and now `sudo` is required to install files in /usr/local

This is the error I was getting without these changes

```
Run curl -sfL "[https://raw.githubusercontent.com/${REVIEWDOG_REPO}/master/install.sh](https://raw.githubusercontent.com/$%7BREVIEWDOG_REPO%7D/master/install.sh)" \
  curl -sfL "[https://raw.githubusercontent.com/${REVIEWDOG_REPO}/master/install.sh](https://raw.githubusercontent.com/$%7BREVIEWDOG_REPO%7D/master/install.sh)" \
    | sh -s -- -b /usr/local/bin/ "${REVIEWDOG_VERSION}"
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    CARGO_TERM_COLOR: always
    CARGO_INCREMENTAL: 0
    REVIEWDOG_REPO: reviewdog/reviewdog
    REVIEWDOG_VERSION: v0.15.0
reviewdog/reviewdog info checking GitHub for tag 'v0.15.0'
reviewdog/reviewdog info found version: 0.15.0 for v0.15.0/Linux/x86_64
install: cannot create regular file '/usr/local/bin/reviewdog': Permission denied
Error: Process completed with exit code 1.
```