### PR TITLE
Split clippy-reviewdog-filter pipe to mitigate broken pipe

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,8 @@ cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}"
 
 cargo clippy --message-format human ${INPUT_CLIPPY_FLAGS}
 
+# Rust ignore SIGPIPE by default: https://github.com/rust-lang/rust/issues/62569
+# This causes `Broken pipe` error when piping to `clippy-reviewdog-filter`
 cargo clippy --message-format json ${INPUT_CLIPPY_FLAGS} 2>&1 \
   | clippy-reviewdog-filter \
   > /tmp/clippy-checkstyle.xml

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,11 +7,14 @@ cargo clippy --message-format human ${INPUT_CLIPPY_FLAGS}
 
 cargo clippy --message-format json ${INPUT_CLIPPY_FLAGS} 2>&1 \
   | clippy-reviewdog-filter \
-  | reviewdog \
+  > /tmp/clippy-checkstyle.xml
+
+reviewdog \
     -f=checkstyle \
     -name="${INPUT_TOOL_NAME}" \
     -level="${INPUT_LEVEL}" \
     -reporter="${INPUT_REPORTER:-github-pr-check}" \
     -filter-mode="${INPUT_FILTER_MODE}" \
     -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
-    ${INPUT_REVIEWDOG_FLAGS}
+    ${INPUT_REVIEWDOG_FLAGS} \
+    < /tmp/clippy-checkstyle.xml


### PR DESCRIPTION
- Sometimes (especially during `on:push`) `Broken pipe` occurs
  - ex: https://github.com/arkedge/c2a-tlmcmddb/issues/42 (https://github.com/arkedge/c2a-tlmcmddb/actions/runs/7523751359/job/20485143596)
- The root cause of this is that SIGPIPE is ignored in Rust's default behavior
  - https://github.com/rust-lang/rust/pull/13158
  - https://github.com/rust-lang/rust/issues/46016
  - https://github.com/rust-lang/rust/issues/62569
- Therefore, temporarily stop pipe directly & passing checkstyle XML to reviewdog via temporary file