### PR TITLE
Change reviewdog default filter mode from "added" to "nofilter"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
 | `tool_name`         | ✓ | Tool name to use for reviewdog reporte | `clippy` |
 | `level`             | ✓ | Report level for reviewdog [info,warning,error] | `warning` |
 | `reporter`          | ✓ | Reporter of reviewdog command [github-pr-check,github-pr-review,github-check] | `github-pr-check` |
-| `filter_mode`       | ✓ | Filtering mode for the reviewdog command [added,diff_context,file,nofilter] | `added` |
+| `filter_mode`       | ✓ | Filtering mode for the reviewdog command [added,diff_context,file,nofilter] | `nofilter` |
 | `fail_on_error`     | ✓ | Exit code for reviewdog when errors are found | `false` |
 | `reviewdog_flags`   |   | Additional reviewdog flags | |
 | `clippy_flags`      |   | Additional clippy flags | |

--- a/action.yml
+++ b/action.yml
@@ -32,8 +32,8 @@ inputs:
   filter_mode:
     description: |
       Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
-      Default is added.
-    default: 'added'
+      Default is nofilter.
+    default: 'nofilter'
     required: true
   fail_on_error:
     description: |


### PR DESCRIPTION
- Resolve #61 
- Change [reviewdog filter mode](https://github.com/reviewdog/reviewdog?tab=readme-ov-file#filter-mode) default config to `nofilter`

`added` filter is very suitable for line-by-line lint use cases such as shell scripts and configuration files.

However, in the context of Rust and clippy, this is not a very appropriate approach.
For example, consider the following structures.

```rust
pub struct A {
  pub b: B,
}

pub struct B {
  pub hoge: u32,
  pub fuga: String,
}
```

Now, suppose that the above code has already been committed, and create a patch to increase the size of B.
In this case, clippy sometimes warns to A that "it might be better to boxed b".

This warning is emitted on the line containing the A structure, so the `added` filter will remove it.
And relationships such as A and B do not necessarily exist on nearby lines or in the same file.
So, neither the `diff_context` filter nor the `file` filter is an appropriate choice.

In addition, since this Action is intended to be used on GitHub, the `nofilter` filter can also output warnings as annotations.
https://github.com/reviewdog/reviewdog?tab=readme-ov-file#filter-mode-support-table

Due to the above reasons, change the default configuration of the reviewdog filter mode in this Action to `nofilter`.